### PR TITLE
Funções de conversão de tipo para instruções JVM

### DIFF
--- a/helper.c
+++ b/helper.c
@@ -68,9 +68,3 @@ u8 double_to_u8(double value) {
     converterU8Double.d = value;
     return converterU8Double.u8;
 }
-
-
-
-
-
-

--- a/helper.h
+++ b/helper.h
@@ -45,4 +45,5 @@ int64_t u8_to_long(u8 value);
 u8 long_to_u8(int64_t value);
 double u8_to_double(u8 value);
 u8 double_to_u8(double value);
+
 #endif

--- a/makefile
+++ b/makefile
@@ -16,6 +16,8 @@ SRCS = reader.c \
        attribute_info.c \
        output.c \
        class_file.c \
+       helper.c \
+       stack_operations.c \
 	   main.c \
 
 # Arquivos objeto
@@ -29,7 +31,9 @@ HEADERS = types.h \
           method_info.h \
           attribute_info.h \
           output.h \
-          class_file.h
+          class_file.h \
+          helper.h \
+          stack_operations.h
 
 # Regra principal
 all: directories $(TARGET)
@@ -72,10 +76,6 @@ $(OBJ_DIR)/attribute_info.o: attribute_info.c attribute_info.h types.h reader.h
 	@echo "Compilando attribute_info.c..."
 	@$(CC) $(CFLAGS) -c attribute_info.c -o $@
 
-
-
-
-
 $(OBJ_DIR)/output.o: output.c output.h types.h
 	@echo "Compilando output.c..."
 	@$(CC) $(CFLAGS) -c output.c -o $@
@@ -88,7 +88,13 @@ $(OBJ_DIR)/main.o: main.c reader.h class_file.h output.h
 	@echo "Compilando main.c..."
 	@$(CC) $(CFLAGS) -c main.c -o $@
 
+$(OBJ_DIR)/helper.o: helper.c helper.h types.h
+	@echo "Compilando helper.c..."
+	@$(CC) $(CFLAGS) -c helper.c -o $@
 
+$(OBJ_DIR)/stack_operations.o: stack_operations.c stack_operations.h types.h helper.h
+	@echo "Compilando stack_operations.c..."
+	@$(CC) $(CFLAGS) -c stack_operations.c -o $@
 
 # Limpeza
 clean:

--- a/stack_operations.c
+++ b/stack_operations.c
@@ -43,7 +43,7 @@ u4 peek_stack(Frame * frame) {
 
 // Funções de conversão de tipo para instruções da JVM
 
-int d2f(Frame * frame, Instruction instruction) {
+int double_to_float(Frame * frame) {
     // Remove os dois valores da pilha (double ocupa 2 slots)
     u4 low = remove_from_stack(frame);
     u4 high = remove_from_stack(frame);
@@ -62,7 +62,7 @@ int d2f(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int d2i(Frame * frame, Instruction instruction) {
+int double_to_int(Frame * frame) {
     u4 low = remove_from_stack(frame);
     u4 high = remove_from_stack(frame);
     
@@ -77,7 +77,7 @@ int d2i(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int d2l(Frame * frame, Instruction instruction) {
+int double_to_long(Frame * frame) {
     u4 low = remove_from_stack(frame);
     u4 high = remove_from_stack(frame);
     
@@ -97,7 +97,7 @@ int d2l(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int f2d(Frame * frame, Instruction instruction) {
+int float_to_double(Frame * frame) {
     u4 float_bits = remove_from_stack(frame);
     float float_value = u4_to_float(float_bits);
     
@@ -113,7 +113,7 @@ int f2d(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int f2i(Frame * frame, Instruction instruction) {
+int float_to_int(Frame * frame) {
     u4 float_bits = remove_from_stack(frame);
     float float_value = u4_to_float(float_bits);
     
@@ -125,7 +125,7 @@ int f2i(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int f2l(Frame * frame, Instruction instruction) {
+int float_to_long(Frame * frame) {
     u4 float_bits = remove_from_stack(frame);
     float float_value = u4_to_float(float_bits);
     
@@ -141,7 +141,7 @@ int f2l(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int i2b(Frame * frame, Instruction instruction) {
+int int_to_byte(Frame * frame) {
     u4 int_bits = remove_from_stack(frame);
     int32_t int_value = u4_to_int(int_bits);
     
@@ -153,7 +153,7 @@ int i2b(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int i2c(Frame * frame, Instruction instruction) {
+int int_to_char(Frame * frame) {
     u4 int_bits = remove_from_stack(frame);
     int32_t int_value = u4_to_int(int_bits);
     
@@ -165,7 +165,7 @@ int i2c(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int i2d(Frame * frame, Instruction instruction) {
+int int_to_double(Frame * frame) {
     u4 int_bits = remove_from_stack(frame);
     int32_t int_value = u4_to_int(int_bits);
     
@@ -181,7 +181,7 @@ int i2d(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int i2f(Frame * frame, Instruction instruction) {
+int int_to_float(Frame * frame) {
     u4 int_bits = remove_from_stack(frame);
     int32_t int_value = u4_to_int(int_bits);
     
@@ -193,7 +193,7 @@ int i2f(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int i2l(Frame * frame, Instruction instruction) {
+int int_to_long(Frame * frame) {
     u4 int_bits = remove_from_stack(frame);
     int32_t int_value = u4_to_int(int_bits);
     
@@ -209,7 +209,7 @@ int i2l(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int i2s(Frame * frame, Instruction instruction) {
+int int_to_short(Frame * frame) {
     u4 int_bits = remove_from_stack(frame);
     int32_t int_value = u4_to_int(int_bits);
     
@@ -221,7 +221,7 @@ int i2s(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int l2d(Frame * frame, Instruction instruction) {
+int long_to_double(Frame * frame) {
     u4 low = remove_from_stack(frame);
     u4 high = remove_from_stack(frame);
     
@@ -240,7 +240,7 @@ int l2d(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int l2f(Frame * frame, Instruction instruction) {
+int long_to_float(Frame * frame) {
     u4 low = remove_from_stack(frame);
     u4 high = remove_from_stack(frame);
     
@@ -255,7 +255,7 @@ int l2f(Frame * frame, Instruction instruction) {
     return 0;
 }
 
-int l2i(Frame * frame, Instruction instruction) {
+int long_to_int(Frame * frame) {
     u4 low = remove_from_stack(frame);
     u4 high = remove_from_stack(frame);
     

--- a/stack_operations.c
+++ b/stack_operations.c
@@ -1,0 +1,271 @@
+#include "types.h"
+#include "helper.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+// Funções de manipulação da pilha de operandos
+
+u4 remove_from_stack(Frame * frame) {
+    if (frame->stack_top == NULL) {
+        fprintf(stderr, "Erro: Tentativa de remover de pilha vazia\n");
+        return 0;
+    }
+    
+    OperandStack * temp = frame->stack_top;
+    u4 value = temp->self;
+    frame->stack_top = temp->next;
+    frame->stack_size--;
+    free(temp);
+    
+    return value;
+}
+
+void add_to_stack(Frame * frame, u4 value) {
+    OperandStack * new_stack = malloc(sizeof(OperandStack));
+    if (new_stack == NULL) {
+        fprintf(stderr, "Erro: Falha na alocação de memória para pilha\n");
+        return;
+    }
+    
+    new_stack->self = value;
+    new_stack->next = frame->stack_top;
+    frame->stack_top = new_stack;
+    frame->stack_size++;
+}
+
+u4 peek_stack(Frame * frame) {
+    if (frame->stack_top == NULL) {
+        fprintf(stderr, "Erro: Tentativa de acessar pilha vazia\n");
+        return 0;
+    }
+    return frame->stack_top->self;
+}
+
+// Funções de conversão de tipo para instruções da JVM
+
+int d2f(Frame * frame, Instruction instruction) {
+    // Remove os dois valores da pilha (double ocupa 2 slots)
+    u4 low = remove_from_stack(frame);
+    u4 high = remove_from_stack(frame);
+    
+    // Reconstrói o double (64 bits)
+    u8 double_bits = ((u8)high << 32) | low;
+    double double_value = u8_to_double(double_bits);
+    
+    // Converte double para float
+    float float_value = (float)double_value;
+    
+    // Converte float para uint32 e empilha
+    u4 float_bits = float_to_u4(float_value);
+    add_to_stack(frame, float_bits);
+    
+    return 0;
+}
+
+int d2i(Frame * frame, Instruction instruction) {
+    u4 low = remove_from_stack(frame);
+    u4 high = remove_from_stack(frame);
+    
+    u8 double_bits = ((u8)high << 32) | low;
+    double double_value = u8_to_double(double_bits);
+    
+    int32_t int_value = (int32_t)double_value;
+    
+    u4 int_bits = int_to_u4(int_value);
+    add_to_stack(frame, int_bits);
+    
+    return 0;
+}
+
+int d2l(Frame * frame, Instruction instruction) {
+    u4 low = remove_from_stack(frame);
+    u4 high = remove_from_stack(frame);
+    
+    u8 double_bits = ((u8)high << 32) | low;
+    double double_value = u8_to_double(double_bits);
+    
+    int64_t long_value = (int64_t)double_value;
+    
+    // Long ocupa 2 slots na pilha
+    u8 long_bits = long_to_u8(long_value);
+    u4 high_bits = (u4)(long_bits >> 32);
+    u4 low_bits = (u4)(long_bits & 0xFFFFFFFF);
+    
+    add_to_stack(frame, low_bits);
+    add_to_stack(frame, high_bits);
+    
+    return 0;
+}
+
+int f2d(Frame * frame, Instruction instruction) {
+    u4 float_bits = remove_from_stack(frame);
+    float float_value = u4_to_float(float_bits);
+    
+    double double_value = (double)float_value;
+    
+    u8 double_bits = double_to_u8(double_value);
+    u4 high_bits = (u4)(double_bits >> 32);
+    u4 low_bits = (u4)(double_bits & 0xFFFFFFFF);
+    
+    add_to_stack(frame, low_bits);
+    add_to_stack(frame, high_bits);
+    
+    return 0;
+}
+
+int f2i(Frame * frame, Instruction instruction) {
+    u4 float_bits = remove_from_stack(frame);
+    float float_value = u4_to_float(float_bits);
+    
+    int32_t int_value = (int32_t)float_value;
+    
+    u4 int_bits = int_to_u4(int_value);
+    add_to_stack(frame, int_bits);
+    
+    return 0;
+}
+
+int f2l(Frame * frame, Instruction instruction) {
+    u4 float_bits = remove_from_stack(frame);
+    float float_value = u4_to_float(float_bits);
+    
+    int64_t long_value = (int64_t)float_value;
+    
+    u8 long_bits = long_to_u8(long_value);
+    u4 high_bits = (u4)(long_bits >> 32);
+    u4 low_bits = (u4)(long_bits & 0xFFFFFFFF);
+    
+    add_to_stack(frame, low_bits);
+    add_to_stack(frame, high_bits);
+    
+    return 0;
+}
+
+int i2b(Frame * frame, Instruction instruction) {
+    u4 int_bits = remove_from_stack(frame);
+    int32_t int_value = u4_to_int(int_bits);
+    
+    int8_t byte_value = (int8_t)int_value;
+    
+    u4 byte_bits = int_to_u4((int32_t)byte_value);
+    add_to_stack(frame, byte_bits);
+    
+    return 0;
+}
+
+int i2c(Frame * frame, Instruction instruction) {
+    u4 int_bits = remove_from_stack(frame);
+    int32_t int_value = u4_to_int(int_bits);
+    
+    int16_t char_value = (int16_t)int_value;
+    
+    u4 char_bits = int_to_u4((int32_t)char_value);
+    add_to_stack(frame, char_bits);
+    
+    return 0;
+}
+
+int i2d(Frame * frame, Instruction instruction) {
+    u4 int_bits = remove_from_stack(frame);
+    int32_t int_value = u4_to_int(int_bits);
+    
+    double double_value = (double)int_value;
+    
+    u8 double_bits = double_to_u8(double_value);
+    u4 high_bits = (u4)(double_bits >> 32);
+    u4 low_bits = (u4)(double_bits & 0xFFFFFFFF);
+    
+    add_to_stack(frame, low_bits);
+    add_to_stack(frame, high_bits);
+    
+    return 0;
+}
+
+int i2f(Frame * frame, Instruction instruction) {
+    u4 int_bits = remove_from_stack(frame);
+    int32_t int_value = u4_to_int(int_bits);
+    
+    float float_value = (float)int_value;
+    
+    u4 float_bits = float_to_u4(float_value);
+    add_to_stack(frame, float_bits);
+    
+    return 0;
+}
+
+int i2l(Frame * frame, Instruction instruction) {
+    u4 int_bits = remove_from_stack(frame);
+    int32_t int_value = u4_to_int(int_bits);
+    
+    int64_t long_value = (int64_t)int_value;
+    
+    u8 long_bits = long_to_u8(long_value);
+    u4 high_bits = (u4)(long_bits >> 32);
+    u4 low_bits = (u4)(long_bits & 0xFFFFFFFF);
+    
+    add_to_stack(frame, low_bits);
+    add_to_stack(frame, high_bits);
+    
+    return 0;
+}
+
+int i2s(Frame * frame, Instruction instruction) {
+    u4 int_bits = remove_from_stack(frame);
+    int32_t int_value = u4_to_int(int_bits);
+    
+    int16_t short_value = (int16_t)int_value;
+    
+    u4 short_bits = int_to_u4((int32_t)short_value);
+    add_to_stack(frame, short_bits);
+    
+    return 0;
+}
+
+int l2d(Frame * frame, Instruction instruction) {
+    u4 low = remove_from_stack(frame);
+    u4 high = remove_from_stack(frame);
+    
+    u8 long_bits = ((u8)high << 32) | low;
+    int64_t long_value = u8_to_long(long_bits);
+    
+    double double_value = (double)long_value;
+    
+    u8 double_bits = double_to_u8(double_value);
+    u4 high_bits = (u4)(double_bits >> 32);
+    u4 low_bits = (u4)(double_bits & 0xFFFFFFFF);
+    
+    add_to_stack(frame, low_bits);
+    add_to_stack(frame, high_bits);
+    
+    return 0;
+}
+
+int l2f(Frame * frame, Instruction instruction) {
+    u4 low = remove_from_stack(frame);
+    u4 high = remove_from_stack(frame);
+    
+    u8 long_bits = ((u8)high << 32) | low;
+    int64_t long_value = u8_to_long(long_bits);
+    
+    float float_value = (float)long_value;
+    
+    u4 float_bits = float_to_u4(float_value);
+    add_to_stack(frame, float_bits);
+    
+    return 0;
+}
+
+int l2i(Frame * frame, Instruction instruction) {
+    u4 low = remove_from_stack(frame);
+    u4 high = remove_from_stack(frame);
+    
+    u8 long_bits = ((u8)high << 32) | low;
+    int64_t long_value = u8_to_long(long_bits);
+    
+    int32_t int_value = (int32_t)long_value;
+    
+    u4 int_bits = int_to_u4(int_value);
+    add_to_stack(frame, int_bits);
+    
+    return 0;
+} 

--- a/stack_operations.h
+++ b/stack_operations.h
@@ -9,20 +9,20 @@ void add_to_stack(Frame * frame, u4 value);
 u4 peek_stack(Frame * frame);
 
 // Funções de conversão de tipo para instruções da JVM
-int d2f(Frame * frame, Instruction instruction);
-int d2i(Frame * frame, Instruction instruction);
-int d2l(Frame * frame, Instruction instruction);
-int f2d(Frame * frame, Instruction instruction);
-int f2i(Frame * frame, Instruction instruction);
-int f2l(Frame * frame, Instruction instruction);
-int i2b(Frame * frame, Instruction instruction);
-int i2c(Frame * frame, Instruction instruction);
-int i2d(Frame * frame, Instruction instruction);
-int i2f(Frame * frame, Instruction instruction);
-int i2l(Frame * frame, Instruction instruction);
-int i2s(Frame * frame, Instruction instruction);
-int l2d(Frame * frame, Instruction instruction);
-int l2f(Frame * frame, Instruction instruction);
-int l2i(Frame * frame, Instruction instruction);
+int double_to_float(Frame * frame);
+int double_to_int(Frame * frame);
+int double_to_long(Frame * frame);
+int float_to_double(Frame * frame);
+int float_to_int(Frame * frame);
+int float_to_long(Frame * frame);
+int int_to_byte(Frame * frame);
+int int_to_char(Frame * frame);
+int int_to_double(Frame * frame);
+int int_to_float(Frame * frame);
+int int_to_long(Frame * frame);
+int int_to_short(Frame * frame);
+int int_to_double(Frame * frame);
+int long_to_float(Frame * frame);
+int long_to_int(Frame * frame);
 
 #endif 

--- a/stack_operations.h
+++ b/stack_operations.h
@@ -1,0 +1,28 @@
+#ifndef STACK_OPERATIONS_H
+#define STACK_OPERATIONS_H
+
+#include "types.h"
+
+// Funções de manipulação da pilha de operandos
+u4 remove_from_stack(Frame * frame);
+void add_to_stack(Frame * frame, u4 value);
+u4 peek_stack(Frame * frame);
+
+// Funções de conversão de tipo para instruções da JVM
+int d2f(Frame * frame, Instruction instruction);
+int d2i(Frame * frame, Instruction instruction);
+int d2l(Frame * frame, Instruction instruction);
+int f2d(Frame * frame, Instruction instruction);
+int f2i(Frame * frame, Instruction instruction);
+int f2l(Frame * frame, Instruction instruction);
+int i2b(Frame * frame, Instruction instruction);
+int i2c(Frame * frame, Instruction instruction);
+int i2d(Frame * frame, Instruction instruction);
+int i2f(Frame * frame, Instruction instruction);
+int i2l(Frame * frame, Instruction instruction);
+int i2s(Frame * frame, Instruction instruction);
+int l2d(Frame * frame, Instruction instruction);
+int l2f(Frame * frame, Instruction instruction);
+int l2i(Frame * frame, Instruction instruction);
+
+#endif 

--- a/types.h
+++ b/types.h
@@ -159,4 +159,33 @@ typedef struct FrameStack {
     Frame * top_frame;
 } FrameStack;
 
+// Estrutura para instruções
+typedef struct Instruction {
+    u1 opcode;
+    u1 * operands;
+    u2 operand_count;
+} Instruction;
+
+// Funções de manipulação da pilha de operandos
+u4 remove_from_stack(Frame * frame);
+void add_to_stack(Frame * frame, u4 value);
+u4 peek_stack(Frame * frame);
+
+// Funções de conversão de tipo para instruções da JVM
+int d2f(Frame * frame, Instruction instruction);
+int d2i(Frame * frame, Instruction instruction);
+int d2l(Frame * frame, Instruction instruction);
+int f2d(Frame * frame, Instruction instruction);
+int f2i(Frame * frame, Instruction instruction);
+int f2l(Frame * frame, Instruction instruction);
+int i2b(Frame * frame, Instruction instruction);
+int i2c(Frame * frame, Instruction instruction);
+int i2d(Frame * frame, Instruction instruction);
+int i2f(Frame * frame, Instruction instruction);
+int i2l(Frame * frame, Instruction instruction);
+int i2s(Frame * frame, Instruction instruction);
+int l2d(Frame * frame, Instruction instruction);
+int l2f(Frame * frame, Instruction instruction);
+int l2i(Frame * frame, Instruction instruction);
+
 #endif

--- a/types.h
+++ b/types.h
@@ -161,33 +161,10 @@ typedef struct FrameStack {
     Frame * top_frame;
 } FrameStack;
 
-// Estrutura para instruções
-typedef struct Instruction {
+/* typedef struct Instruction {
     u1 opcode;
     u1 * operands;
     u2 operand_count;
 } Instruction;
-
-// Funções de manipulação da pilha de operandos
-u4 remove_from_stack(Frame * frame);
-void add_to_stack(Frame * frame, u4 value);
-u4 peek_stack(Frame * frame);
-
-// Funções de conversão de tipo para instruções da JVM
-int d2f(Frame * frame, Instruction instruction);
-int d2i(Frame * frame, Instruction instruction);
-int d2l(Frame * frame, Instruction instruction);
-int f2d(Frame * frame, Instruction instruction);
-int f2i(Frame * frame, Instruction instruction);
-int f2l(Frame * frame, Instruction instruction);
-int i2b(Frame * frame, Instruction instruction);
-int i2c(Frame * frame, Instruction instruction);
-int i2d(Frame * frame, Instruction instruction);
-int i2f(Frame * frame, Instruction instruction);
-int i2l(Frame * frame, Instruction instruction);
-int i2s(Frame * frame, Instruction instruction);
-int l2d(Frame * frame, Instruction instruction);
-int l2f(Frame * frame, Instruction instruction);
-int l2i(Frame * frame, Instruction instruction);
-
+ */
 #endif


### PR DESCRIPTION
> Aviso: Eu não tinha total clareza do que era esperado neste trabalho, então segui a orientação de implementar as funções de conversão de tipo para instruções da JVM, baseando no exemplo do projeto passado e no que consegui entender da estrutura do projeto atual.
O que foi feito
Implementei funções de conversão de tipo (ex: d2f, i2d, l2f, etc) seguindo o padrão de um interpretador de JVM, manipulando a pilha de operandos (Frame).
Criei helpers para manipulação da pilha (add_to_stack, remove_from_stack).
Adaptei a estrutura para permitir a execução dessas instruções, mesmo que o projeto atualmente seja mais voltado para parsing do .class do que execução de bytecode.
Diferença em relação ao projeto passado
No projeto passado, as funções de conversão já eram parte de um interpretador, com execução real de bytecode e manipulação da pilha.
No projeto atual, precisei criar parte dessa estrutura (manipulação de pilha, instrução) para conseguir implementar as conversões, pois originalmente o projeto era apenas um parser/leitor de arquivos .class.